### PR TITLE
upgrade to laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ '8.0','8.3' ]
+        php: [ '8.2','8.3' ]
         stability: [ prefer-lowest, prefer-stable ]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,12 +6,12 @@ on:
       - master
       - main
     paths-ignore:
-      - '**.md'
-      - '**.yml'
+      - "**.md"
+      - "**.yml"
   pull_request:
     paths-ignore:
-      - '**.md'
-      - '**.yml'
+      - "**.md"
+      - "**.yml"
 jobs:
   tests:
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
@@ -21,8 +21,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ '8.2','8.3' ]
-        stability: [ prefer-lowest, prefer-stable ]
+        php: ["8.0", "8.4"]
+        stability: [prefer-lowest, prefer-stable]
 
     steps:
       - name: Checkout Code
@@ -67,6 +67,6 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ env.CC_TOKEN }}
         with:
-          coverageCommand: ''
+          coverageCommand: ""
           coverageLocations: ./coverage.xml:clover
         if: ${{ !env.ACT && env.CC_TOKEN && matrix.stability == 'prefer-stable' && matrix.php == '8.2' }}

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "laravel/serializable-closure": "^v1.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^7|^8.5|^9.0",
-        "phpunit/phpunit": "^9.6.10|^10.0"
+        "orchestra/testbench": "^7|^8.5|^9.0|^10.0",
+        "phpunit/phpunit": "^9.6.10|^10.0|^11.0"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "laravel/serializable-closure": "^v1.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": ">=8.0",
         "laravel/serializable-closure": "^v1.3"
     },
     "require-dev": {


### PR DESCRIPTION
- PHP version 8.2 required
- Added support for orchestra/testbench version ^10.0
- Added support for phpunit/phpunit version ^11.0
- Ci: PHP tests with versions 8.2 and 8.3