### PR TITLE
Permit Laravel Serializable Closure v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "laravel/serializable-closure": "^v1.3"
+        "laravel/serializable-closure": "^v1.3|^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7|^8.5|^9.0|^10.0",


### PR DESCRIPTION
This makes it more widely installable across Laravel 12 projects as in most instances they'll already have laravel/serializable-closure installed and locked to v2.

Tested and working with no issues.